### PR TITLE
Add nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ Thumbs.db
 
 .idea
 moc_predefs.h
+
+# Nix
+# --------
+/result

--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,0 @@
-{ stdenv, lib, qmake, qt5, wrapQtAppsHook }: 
-
-stdenv.mkDerivation rec {
-  pname = "tab-ui";
-  version = "1.0";
-  src = ./.;
-  buildInputs = [ qt5.full ];
-  nativeBuildInputs = [ qmake wrapQtAppsHook ]; 
-}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1734323986,
+        "narHash": "sha256-m/lh6hYMIWDYHCAsn81CDAiXoT3gmxXI9J987W5tZrE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "394571358ce82dff7411395829aa6a3aad45b907",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,77 @@
+{
+  description = "Flake for the bar tab frontend application (tab-ui)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+  } @ inputs: let
+    # This list of architectures provides the supported systems to the wrapper function below.
+    # It basically defines which architectures can build and run the tab-ui application.
+    supportedSystems = [
+      "aarch64-darwin"
+      "x86_64-linux"
+    ];
+
+    # This helper function is used to make the flake outputs below more DRY. It looks a bit intimidating but that's
+    # mostly because of the functional programming nature of Nix. I recommend reading
+    # [Nix language basics](https://nix.dev/tutorials/nix-language.html) and search online for resources about
+    # functional programming paradigms.
+    #
+    # Basically this function makes it so that instead of declaring outputs for every architecture as the flake schema
+    # expects, e.g.:
+    #
+    # packages = {
+    #   "x86_64-linux" = {
+    #     ...
+    #   };
+    #   "aarch64-darwin" = {
+    #     ...
+    #   };
+    # };
+    #
+    # we can define each output below (package, formatter, ...) once for all the architectures / systems.
+    #
+    # It is a simplified version of [flake-utils](https://github.com/numtide/flake-utils). Check it out to learn more!
+    #
+    forAllSystems = function:
+      nixpkgs.lib.genAttrs supportedSystems (system:
+        function (import nixpkgs {
+          inherit system;
+        }));
+  in {
+    formatter = forAllSystems (pkgs: pkgs.alejandra);
+
+    packages = forAllSystems (pkgs: {
+      # There's only one package defined in this flake, so let's make that the default one:
+      default = pkgs.stdenv.mkDerivation rec {
+        pname = "tab-ui";
+
+        # tab-ui does not have versioned releases. To still keep track of some sort of version (a Nix package requires
+        # it and it's also convenient for debugging) and not having to make up something arbitrary like "1.0", we'll
+        # use the Nix builtin substring function to extract the first 7 characters of the git commit hash that the
+        # build of this package is based on and use that as the version indicator.
+        # To avoid duplication or creating extra variables through let bindings, we'll make the attribute set passed to
+        # the mkDerivation function above recursive by adding the `rec` keyword. This allows us to reference the
+        # revision attribute in the fetchgit function below through `src.rev`.
+        version = builtins.substring 0 7 src.rev;
+
+        src = pkgs.fetchgit {
+          url = "https://github.com/voidwarranties/tab-ui.git";
+          rev = "90c0d413625e53826605c5b92fcc02e5b4a8b736";
+          hash = "sha256-uQ/BIEYArVs0KIwfDNQbqxrTSbwZ6NIgW4KMwz7xSHk=";
+          fetchSubmodules = true;
+        };
+
+        buildInputs = with pkgs.qt5; [
+          qmake
+          qtquickcontrols2
+          wrapQtAppsHook
+        ];
+      };
+    });
+  };
+}


### PR DESCRIPTION
@snowy-e12l you were right, it makes more sense to put the Nix package expression into the repository of each application (tab-ui, backtab, ...) as a Nix flake and then we'll use them as inputs in the nix-configs flake. That way others can also choose to use the packages in their own flakes in the future.

What I've done:
- Added a `flake.nix` and deleted the now obsolete `default.nix`.
- I managed to strip down the Qt5 dependencies to the bare minimum required to build (and run) the application. `qt5.full`, among much other stuff we don't need, includes [QtWebEngine](https://wiki.qt.io/QtWebEngine) and that would not compile without errors on my Apple M1 (aarch64-darwin) for some reason. After looking into why the build is failing for about 5 minutes, I realized we don't even need it for this application! Presumably QtWebEngine wraps Chromium into something for use in Qt. Sounds like a world of pain and very unnecessary. Moving on!
- Added the `forAllSystems` function to the flake to DRY it up a bit because I wanted to make tab-ui work on my Macbook.
- I've tried to explain things a bit with some comments in the flake.

When this is merged you should be able to run tab-ui simply with a `nix run github:voidwarranties/tab-ui`. We can do the flake for [backtab](https://github.com/voidwarranties/backtab) together next time in the space if you'd like. It's going to look pretty much the same except that we'll also define a NixOS module for running the backtab server as a systemd service. Similar to what I've [done for Cryptpad](https://github.com/michaelshmitty/cryptpad-flake/blob/main/cryptpad-module.nix).