### PR TITLE
Add patch to change the window title for VoidWarranties

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -71,6 +71,10 @@
           qtquickcontrols2
           wrapQtAppsHook
         ];
+
+        patches = [
+          ./patches/0001-main.qml-change-window-title-for-voidwarranties.patch
+        ];
       };
     });
   };

--- a/patches/0001-main.qml-change-window-title-for-voidwarranties.patch
+++ b/patches/0001-main.qml-change-window-title-for-voidwarranties.patch
@@ -1,0 +1,13 @@
+diff --git a/main.qml b/main.qml
+index dcb56a1..7fc4ee0 100644
+--- a/main.qml
++++ b/main.qml
+@@ -13,7 +13,7 @@ Window {
+     width: 640
+     height: 480
+     visibility: Window.Maximized
+-    title: qsTr("Hackerspace.gent tab-ui")
++    title: qsTr("VoidWarranties Barputer UI")
+     color: "black"
+ 
+     property int fontSize: 16


### PR DESCRIPTION
This PR adds a patch to the tab-ui source code changing the window title from "Hackerspace.gent ..." to "VoidWarranties ...". The reasoning for doing it through a patch that gets applied during package build is as follows:

The upstream tab-ui project does not support setting the window title through configuration. The only way to change it is by modifying the source code. Although we maintain our own fork of tab-ui with some new features already added, it feels more appropriate to not explicitly replace Hackerspace Gent strings with our own. This is where the patch comes in. It is applied to the source code right before Nix builds the package.
Conversely, disabling the patch and thus preventing the window title to change is as easy as [commenting out the line where the patch gets applied](https://github.com/voidwarranties/tab-ui/pull/2/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R76). To avoid cluttering the root of the project, patches go into the newly created `patches` directory.