### PR TITLE
Add patch to simplify timestamp format in logview

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,7 @@
         patches = [
           ./patches/0001-main.qml-change-window-title-for-voidwarranties.patch
           ./patches/0002-show-product-prices.patch
+          ./patches/0003-format-logview.patch
         ];
       };
     });

--- a/patches/0003-format-logview.patch
+++ b/patches/0003-format-logview.patch
@@ -1,0 +1,13 @@
+diff --git a/LogView.qml b/LogView.qml
+index 4244e22..aa74e9a 100644
+--- a/LogView.qml
++++ b/LogView.qml
+@@ -17,7 +17,7 @@ Rectangle {
+                    }
+ 
+             text: {
+-                var ts_string = "<" + timestamp.toLocaleString(Qt.locale(), "--MM-dd HH:mm") + "> ";
++                var ts_string = "[" + timestamp.toLocaleString(Qt.locale(), "MM-dd HH:mm") + "] ";
+                 var suffix = "";
+ 
+                 switch (status) {


### PR DESCRIPTION
The current timestamp format: `<--MM-dd HH:mm>`
This patch (added to flake) simplifies it by removing the leading dashes and changing to square brackets: `[MM-dd HH:mm]`